### PR TITLE
Fix new(-file=>*GLOB) in Image::Xpm [upstream #7438]

### DIFF
--- a/Xbm.pm
+++ b/Xbm.pm
@@ -138,7 +138,9 @@ sub new { # Class and object method
     }
 
     my $file = $self->get( '-file' ) ;
-    $self->load if defined $file and -r $file and not $self->{'-bits'} ;
+    if (defined $file and not $self->{-bits}) {
+        $self->load if ref $file or -r $file;
+    }
 
     croak "new() `$file' not found or unreadable" 
     if defined $file and not defined $self->get( '-width' ) ;


### PR DESCRIPTION
Sorry, I don't really know what the upstream issue number(? checkout number) references, but this still applies to trunk clearly, so forwarding thusly.

Found-at: libimage-base-bundle-perl (1.0.7-2)  debian/patches/Image-Xbm/01_fix_GLOB_open.diff